### PR TITLE
Change margin to fix emoji tops cut in Safari iOS

### DIFF
--- a/less/forum.less
+++ b/less/forum.less
@@ -1,6 +1,6 @@
 img.emoji {
   height: 1.5em;
-  margin: 0 .1em;
+  margin: .1em .1em 0;
   vertical-align: -0.3em;
 }
 


### PR DESCRIPTION
**Fixes flarum/core#1668**

Adds `.1em` margin to the top of emojis, only seems to push paragraph down `.1em` if emoji is found in first line.

Tested on Safari, iOS 12, iPad Air.