### PR TITLE
fix: Resolved emoji showing through inline spoiler

### DIFF
--- a/less/forum.less
+++ b/less/forum.less
@@ -2,6 +2,9 @@ img.emoji {
   height: 1.5em;
   margin: 0 .1em;
   vertical-align: -0.3em;
+  .spoiler & {
+    visibility: hidden;
+  }
 }
 
 .EmojiDropdown {


### PR DESCRIPTION
Hides the emoji until the inline spoiler is clicked

Part of the fix for https://github.com/flarum/core/issues/2053

Before clicking:
![image](https://user-images.githubusercontent.com/3457368/76146580-ec410600-6061-11ea-805f-24368e6cc3ca.png)

After Clicking:
![image](https://user-images.githubusercontent.com/3457368/76146587-f531d780-6061-11ea-91e0-aa75e041b334.png)
