### PR TITLE
CDN acceleration

### DIFF
--- a/js/src/forum/addComposerAutocomplete.js
+++ b/js/src/forum/addComposerAutocomplete.js
@@ -87,7 +87,7 @@ export default function addComposerAutocomplete() {
                 onmouseenter={function() {
                   dropdown.setIndex($(this).parent().index() - 1);
                 }}>
-                  <img alt={emoji} class="emoji" draggable="false" src={'//cdn.jsdelivr.net/gh/twitter/twemoji/assets/72x72/' + code + '.png'}/>
+                  <img alt={emoji} class="emoji" draggable="false" src={'//cdn.jsdelivr.net/gh/twitter/twemoji@12/assets/72x72/' + code + '.png'}/>
                   {name}
               </button>
             );

--- a/js/src/forum/addComposerAutocomplete.js
+++ b/js/src/forum/addComposerAutocomplete.js
@@ -87,7 +87,7 @@ export default function addComposerAutocomplete() {
                 onmouseenter={function() {
                   dropdown.setIndex($(this).parent().index() - 1);
                 }}>
-                  <img alt={emoji} class="emoji" draggable="false" src={'//twemoji.maxcdn.com/2/72x72/' + code + '.png'}/>
+                  <img alt={emoji} class="emoji" draggable="false" src={'//cdn.jsdelivr.net/gh/twitter/twemoji/assets/72x72/' + code + '.png'}/>
                   {name}
               </button>
             );


### PR DESCRIPTION
Use jsDelivr to increase the loading speed of MaxCDN in China.
In China, sometimes the speed of loading twemoji from MaxCDN can be slow. It is best to use jsdelivr instead, which [has many CDN nodes in China](https://www.jsdelivr.com/network#china).