### PR TITLE
Fix bug with Twemoji frontend rendering

### DIFF
--- a/js/src/forum/renderEmoji.js
+++ b/js/src/forum/renderEmoji.js
@@ -14,12 +14,39 @@ const options = {
   }),
 };
 
+/**
+ * Parses an HTML string into a `<body>` node containing the HTML content.
+ *
+ * Vanilla JS implementation of jQuery's `$.parseHTML()`,
+ * sourced from http://youmightnotneedjquery.com/
+ */
+function parseHTML(str) {
+  const tmp = document.implementation.createHTMLDocument();
+  tmp.body.innerHTML = str;
+
+  return tmp.body;
+}
+
 export default function renderEmoji() {
   override(Post.prototype, 'contentHtml', function (original) {
     const contentHtml = original();
 
     if (this.oldContentHtml !== contentHtml) {
-      this.emojifiedContentHtml = twemoji.parse(contentHtml, options);
+      // We need to parse the HTML string into a DOM node, then give it to Twemoji.
+      //
+      // This prevents some issues with the default find-replace that would be performed
+      // on a string passed to `Twemoji.parse()`.
+      //
+      // The parse function can only handle a single DOM node provided, so we need to
+      // wrap it in a node. In our `parseHTML` implementation, we wrap it in a `<body>`
+      // element. This gets stripped below.
+      //
+      // See https://github.com/flarum/core/issues/2958
+      const emojifiedDom = twemoji.parse(parseHTML(contentHtml), options);
+
+      // Steal the HTML string inside the emojified DOM `<body>` tag.
+      this.emojifiedContentHtml = emojifiedDom.innerHTML;
+
       this.oldContentHtml = contentHtml;
     }
 


### PR DESCRIPTION
Fixes https://github.com/flarum/core/issues/2958

----

Currently, we're passing a string to `Twemoji.parse()`. This isn't the recommended method as it comes without some security benefits. When `parse()` is provided with a string, it just performs a blind find-replace of emojis with `<img>` tags, no matter where they are in the string. See more: https://github.com/twitter/twemoji#dom-parsing

The reason that this doesn't happen in the preview stage is that the TextFormatter provides us with an HTMLElement rather than an HTML string. This is provided to the Twemoji parser which then only replaces text nodes which contain emoji with `<img>¬ tags.

To fix this, I've added a helper function that takes an HTML string as input and returns that string as DOM nodes, which are the children of a new `<body>` element. This body element is passed to the Twemoji parser, which does safer checks when replacing, then the contents of the body element are returned as the new `contentHtml` of the post.