### PR TITLE
fix: errors with composer reuse

### DIFF
--- a/js/src/forum/addComposerAutocomplete.js
+++ b/js/src/forum/addComposerAutocomplete.js
@@ -40,7 +40,7 @@ export default function addComposerAutocomplete() {
       dropdown.hide();
     };
 
-    params.inputListeners.push(function (e) {
+    params.inputListeners.push(() => {
       const selection = this.attrs.composer.editor.getSelectionRange();
 
       const cursor = selection[0];

--- a/js/src/forum/addComposerAutocomplete.js
+++ b/js/src/forum/addComposerAutocomplete.js
@@ -41,7 +41,7 @@ export default function addComposerAutocomplete() {
     };
 
     params.inputListeners.push(function (e) {
-      const selection = app.composer.editor.getSelectionRange();
+      const selection = this.attrs.composer.editor.getSelectionRange();
 
       const cursor = selection[0];
 
@@ -50,7 +50,7 @@ export default function addComposerAutocomplete() {
       // Search backwards from the cursor for an ':' symbol. If we find
       // one and followed by a whitespace, we will want to show the
       // autocomplete dropdown!
-      const lastChunk = app.composer.editor.getLastNChars(15);
+      const lastChunk = this.attrs.composer.editor.getLastNChars(15);
       absEmojiStart = 0;
       for (let i = lastChunk.length - 1; i >= 0; i--) {
         const character = lastChunk.substr(i, 1);
@@ -134,7 +134,7 @@ export default function addComposerAutocomplete() {
             m.render($container[0], dropdown.render());
 
             dropdown.show();
-            const coordinates = app.composer.editor.getCaretCoordinates(absEmojiStart);
+            const coordinates = this.attrs.composer.editor.getCaretCoordinates(absEmojiStart);
             const width = dropdown.$().outerWidth();
             const height = dropdown.$().outerHeight();
             const parent = dropdown.$().offsetParent();


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->
Re-using the TextEditor outside of the composer causes errors, as this extension attempts to access `app.composer` instead of `this.attrs.composer`.

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [x] Core developer confirmed locally this works as intended.
- [x] Tests have been added, or are not appropriate here.
