### PR TITLE
Use loli cdn to solve jsdelivr unavailable in CN

### DIFF
--- a/js/src/forum/cdn.js
+++ b/js/src/forum/cdn.js
@@ -2,4 +2,4 @@ import twemoji from 'twemoji';
 
 export const version = /([0-9]+).[0-9]+.[0-9]+/g.exec(twemoji.base)[1];
 
-export default `https://cdn.jsdelivr.net/gh/twitter/twemoji@${version}/assets/`;
+export default `https://cdnjs.loli.net/ajax/libs/twemoji/13.0.0/`;


### PR DESCRIPTION
JSDELIVR was blocked by mainland China for some reason, so using CDNJS. Loli.net to replace JSDELIVR to ensure the access of mainland Chinese users (translate by google)